### PR TITLE
Dade becomes Miami-Dade

### DIFF
--- a/counties.json
+++ b/counties.json
@@ -344,7 +344,7 @@
       "Clay",
       "Collier",
       "Columbia",
-      "Dade",
+      "Miami-Dade",
       "De Soto",
       "Dixie",
       "Duval",


### PR DESCRIPTION
Dade becomes Miami-Dade. https://en.wikipedia.org/wiki/Miami-Dade_County,_Florida